### PR TITLE
Process terraform modules in terragrunt files

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,4 +19,7 @@ Terraform support for [`dependabot-core`][core-repo].
    $ bundle exec rspec spec
    ```
 
+Note:  terraform-config-inspect is expected to be found in
+`/opt/go/gopath/bin`.
+
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -54,7 +54,7 @@ module Dependabot
           next unless name == "source"
 
           @dependency_set << build_terraform_dependency(
-            file, "terragrunt source", [Hash[name, details]]
+            file, "", [Hash[name, details]]
           )
         end
       end
@@ -66,16 +66,25 @@ module Dependabot
           next unless name == "source"
 
           @dependency_set << build_terraform_dependency(
-            file, "terragrunt_source", [Hash[name, details]]
+            file, "", [Hash[name, details]]
           )
+        end
+      end
+
+      def dependency_name(source, name)
+        if name != ""
+          source[:type] == "registry" ? source[:module_identifier] : name
+        elsif Source.from_url(source[:url])
+          Source.from_url(source[:url]).repo
+        else
+          source[:url]
         end
       end
 
       def build_terraform_dependency(file, name, details)
         details = details.first if details.is_a?(Array)
         source = source_from(details)
-        dep_name =
-          source[:type] == "registry" ? source[:module_identifier] : name
+        dep_name = dependency_name(source, name)
         version_req = details["version"]&.strip
         version =
           if source[:type] == "git" then version_from_ref(source[:ref])

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -60,14 +60,22 @@ module Dependabot
       end
 
       def parse_terragrunt_legacy_file(file)
-        modules = parsed_file(file).fetch("terraform", []).
-                  map { |k, v| [k, v] }.to_h
-        modules.each do |name, details|
-          next unless name == "source"
+        module_list = parsed_file(file).fetch("terragrunt", [])
 
-          @dependency_set << build_terraform_dependency(
-            file, "", [Hash[name, details]]
-          )
+        module_list.each do |modules|
+          modules.each do |terragrunt_module, terragrunt_module_details|
+            next unless terragrunt_module == "terraform"
+
+            terragrunt_module_details.each do |module_details|
+              module_details.each do |name, details|
+                next unless name == "source"
+
+                @dependency_set << build_terraform_dependency(
+                  file, "", [Hash[name, details]]
+                )
+              end
+            end
+          end
         end
       end
 

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -50,6 +50,7 @@ module Dependabot
       def parse_terragrunt_file(file)
         modules = parsed_file(file).fetch("terraform", []).
                   map { |k, v| [k, v] }.to_h
+
         modules.each do |name, details|
           next unless name == "source"
 
@@ -60,21 +61,18 @@ module Dependabot
       end
 
       def parse_terragrunt_legacy_file(file)
-        module_list = parsed_file(file).fetch("terragrunt", [])
+        modules = parsed_file(file).fetch("terragrunt", [])[0].
+                  map { |k, v| [k, v] }.to_h
 
-        module_list.each do |modules|
-          modules.each do |terragrunt_module, terragrunt_module_details|
-            next unless terragrunt_module == "terraform"
+        return unless modules.key?("terraform")
 
-            terragrunt_module_details.each do |module_details|
-              module_details.each do |name, details|
-                next unless name == "source"
+        modules["terraform"].each do |terraform_module|
+          terraform_module.each do |name, details|
+            next unless name == "source"
 
-                @dependency_set << build_terraform_dependency(
-                  file, "", [Hash[name, details]]
-                )
-              end
-            end
+            @dependency_set << build_terraform_dependency(
+              file, "", [Hash[name, details]]
+            )
           end
         end
       end

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -66,7 +66,7 @@ module Dependabot
           next unless name == "source"
 
           @dependency_set << build_terraform_dependency(
-            file, "terragrunt source", [Hash[name, details]]
+            file, "terragrunt_source", [Hash[name, details]]
           )
         end
       end
@@ -87,29 +87,6 @@ module Dependabot
           package_manager: "terraform",
           requirements: [
             requirement: version_req,
-            groups: [],
-            file: file.name,
-            source: source
-          ]
-        )
-      end
-
-      def build_terragrunt_dependency(file, details)
-        source = source_from(details)
-        dep_name =
-          if Source.from_url(source[:url])
-            Source.from_url(source[:url]).repo
-          else
-            source[:url]
-          end
-
-        version = version_from_ref(source[:ref])
-        Dependency.new(
-          name: dep_name,
-          version: version,
-          package_manager: "terraform",
-          requirements: [
-            requirement: nil,
             groups: [],
             file: file.name,
             source: source


### PR DESCRIPTION
The dependencies, i.e., sources, within a "terraform" module of a terragrunt file were being ignored.  Now the sources are being handled the same way as for terraform files.