### PR TITLE
Add Terraform parser tests for edge cases

### DIFF
--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -574,6 +574,76 @@ RSpec.describe Dependabot::Terraform::FileParser do
       end
     end
 
+    context "with a legacy terragrunt file, no terraform key" do
+      let(:files) { [terragrunt_file] }
+      let(:terragrunt_file) do
+        Dependabot::DependencyFile.new(
+          name: "main.tfvars",
+          content: terragrunt_body
+        )
+      end
+      let(:terragrunt_body) do
+        fixture("config_files", terragrunt_fixture_name)
+      end
+      let(:terragrunt_fixture_name) { "terraform_noterraform.tfvars" }
+      its(:length) { is_expected.to eq(0) }
+    end
+
+    context "with a legacy terragrunt file, terraform key, no source" do
+      let(:files) { [terragrunt_file] }
+      let(:terragrunt_file) do
+        Dependabot::DependencyFile.new(
+          name: "main.tfvars",
+          content: terragrunt_body
+        )
+      end
+      let(:terragrunt_body) do
+        fixture("config_files", terragrunt_fixture_name)
+      end
+      let(:terragrunt_fixture_name) { "terraform_nosource.tfvars" }
+      its(:length) { is_expected.to eq(0) }
+    end
+
+    context "with a legacy terragrunt file, terraform key with source" do
+      let(:files) { [terragrunt_file] }
+      let(:terragrunt_file) do
+        Dependabot::DependencyFile.new(
+          name: "main.tfvars",
+          content: terragrunt_body
+        )
+      end
+      let(:terragrunt_body) do
+        fixture("config_files", terragrunt_fixture_name)
+      end
+      let(:terragrunt_fixture_name) { "terraform.tfvars" }
+
+      its(:length) { is_expected.to eq(1) }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: "main.tfvars",
+            source: {
+              type: "git",
+              url: "git@github.com:gruntwork-io/modules-example.git",
+              branch: nil,
+              ref: "v0.0.2"
+            }
+          }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("gruntwork-io/modules-example")
+          expect(dependency.version).to eq("0.0.2")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+    end
+
     context "with a legacy terragrunt file" do
       let(:files) { [terragrunt_file] }
       let(:terragrunt_file) do
@@ -652,6 +722,21 @@ RSpec.describe Dependabot::Terraform::FileParser do
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
+    end
+
+    context "with a terragrunt file with no source" do
+      let(:files) { [terragrunt_file] }
+      let(:terragrunt_file) do
+        Dependabot::DependencyFile.new(
+          name: "main.hcl",
+          content: terragrunt_body
+        )
+      end
+      let(:terragrunt_body) do
+        fixture("config_files", terragrunt_fixture_name)
+      end
+      let(:terragrunt_fixture_name) { "terragrunt_nosource.hcl" }
+      its(:length) { is_expected.to eq(0) }
     end
   end
 end

--- a/terraform/spec/fixtures/config_files/terraform.tfvars
+++ b/terraform/spec/fixtures/config_files/terraform.tfvars
@@ -1,0 +1,9 @@
+terragrunt = {
+  terraform {
+    source = "git::git@github.com:gruntwork-io/modules-example.git//consul?ref=v0.0.2"
+  }
+
+  include {
+    path = "${find_in_parent_folders()}"
+  }
+}

--- a/terraform/spec/fixtures/config_files/terraform_nosource.tfvars
+++ b/terraform/spec/fixtures/config_files/terraform_nosource.tfvars
@@ -1,0 +1,8 @@
+terragrunt = {
+  terraform {
+  }
+
+  include {
+    path = "${find_in_parent_folders()}"
+  }
+}

--- a/terraform/spec/fixtures/config_files/terraform_noterraform.tfvars
+++ b/terraform/spec/fixtures/config_files/terraform_noterraform.tfvars
@@ -1,0 +1,5 @@
+terragrunt = {
+  include {
+    path = "${find_in_parent_folders()}"
+  }
+}

--- a/terraform/spec/fixtures/config_files/terragrunt_nosource.hcl
+++ b/terraform/spec/fixtures/config_files/terragrunt_nosource.hcl
@@ -1,0 +1,5 @@
+include {
+  path = find_in_parent_folders()
+}
+terraform {
+}


### PR DESCRIPTION
Added test cases related to terragrunt legacy files - files with no terraform key or no source specified.  Added a test case related to the new-style terragrunt file where no source was specified.